### PR TITLE
Miner stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ launch.json
 config.env
 save_pid.txt
 output.log
+/.idea/*

--- a/db.js
+++ b/db.js
@@ -32,12 +32,13 @@ export async function InsertBlockTableData(client, nodeInfo, blocks) {
       block.totalDifficulty.toString(),
       block.hash,
       JSON.stringify(block),
+      block.miner
     ];
     values.push(value);
   }
 
   const insertQuery = format(
-    "INSERT INTO blocks (context , location , number , timestamp , gas_limit , gas_used , difficulty , network_difficulty , hash , header) VALUES %L ",
+    "INSERT INTO blocks (context , location , number , timestamp , gas_limit , gas_used , difficulty , network_difficulty , hash , header, miner) VALUES %L ",
     values
   );
 


### PR DESCRIPTION
What to do next?
1) Stop old script version
2) pgAdmin: 
ALTER TABLE blocks ADD COLUMN miner character varying COLLATE pg_catalog."default"
3) Run a new version of the script, check if the miners fields are added to the latest blocks
4) pgAdmin:  
UPDATE public.blocks SET miner = header::json->>'miner' WHERE miner ISNULL;
5) Done! Now all rows have a miner property